### PR TITLE
New package: TestFoo v0.1.678

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -3,3 +3,4 @@ uuid = "23a5b13b-685a-48af-83c5-6c0fa14daa8c"
 repo = "https://github.com/registratortestorg/AnotherRegistry"
 
 [packages]
+59f89287-af9b-403b-8b2b-07a76ab69732 = { name = "TestFoo", path = "T/TestFoo" }

--- a/T/TestFoo/Deps.toml
+++ b/T/TestFoo/Deps.toml
@@ -1,0 +1,2 @@
+[0]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/T/TestFoo/Package.toml
+++ b/T/TestFoo/Package.toml
@@ -1,0 +1,4 @@
+name = "TestFoo"
+uuid = "59f89287-af9b-403b-8b2b-07a76ab69732"
+repo = "https://github.com/JuliaComputing/JHubRegistratorTest.git"
+subdir = "TestFoo"

--- a/T/TestFoo/Versions.toml
+++ b/T/TestFoo/Versions.toml
@@ -1,0 +1,2 @@
+["0.1.678"]
+git-tree-sha1 = "9b84c5a77da449f668fee2f30dbba57715f70ed5"


### PR DESCRIPTION
- Registering package: TestFoo
- Repository: https://github.com/JuliaComputing/JHubRegistratorTest
- Created by: JuliaHub user "admin"
- Version: v0.1.678
- Commit: bbac656f419d9daa40eca5c33c04dcadd16008ff
- Git reference: HEAD
- Description: Repo for all the registrator testing needs